### PR TITLE
Add a basic test case to compare-and-submit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,11 @@ setup(
     entry_points={
         'xblock.v1': [
             'submit-and-compare = submit_and_compare:SubmitAndCompareXBlock',
+        ],
+        'xblock.test.v0': [
+            'test-submit-and-compare = submit_and_compare_tests:TestSubmitAndCompare',
         ]
+
     },
     package_data=package_data("submit_and_compare", "static"),
 )

--- a/submit_and_compare/submit_and_compare.py
+++ b/submit_and_compare/submit_and_compare.py
@@ -129,7 +129,8 @@ class SubmitAndCompareXBlock(XBlock):
         Save student answer
         '''
         self.student_answer = submissions['answer']
-        return {'success': True}
+        return {'success': True,
+                'answer': self.student_answer}
 
     @XBlock.json_handler
     def studio_submit(self, submissions, suffix=''):
@@ -177,7 +178,7 @@ class SubmitAndCompareXBlock(XBlock):
 
         return {
             'result': 'success',
-            'hints': hints,
+            'hints': hints
         }
 
     @XBlock.json_handler

--- a/submit_and_compare_tests/__init__.py
+++ b/submit_and_compare_tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_subcomp import TestSubmitAndCompare

--- a/submit_and_compare_tests/test_subcomp.py
+++ b/submit_and_compare_tests/test_subcomp.py
@@ -1,0 +1,78 @@
+'''
+Tests for the Submit-and-Compare XBlock
+'''
+
+import json
+import sys
+
+from openedx.tests.xblock_integration.xblock_testcase import XBlockTestCase
+
+
+# pylint: disable=abstract-method
+class TestSubmitAndCompare(XBlockTestCase):
+    """
+    Basic tests for the Submit and Compare XBlocks. We set up a page
+    with the block, make sure the page renders, submit an answer, make
+    sure we stored it, pull a few hints, and call it quits.
+    """
+
+    olx_scenarios = {  # Currently not used
+    }
+
+    # This is a stop-gap until we can load OLX and/or OLX from
+    # normal workbench scenarios
+    test_configuration = [
+        {
+            "urlname": "submit_and_compare_test_case",
+            "xblocks": [  # Stopgap until we handle OLX
+                {
+                    'blocktype': 'submit-and-compare',
+                    'urlname': 'submit_0'
+                }
+            ]
+        }
+    ]
+
+    def student_submit(self, block, answer):
+        """
+        Make an AJAX call to the XBlock, and assert the state is as
+        desired.
+        """
+        resp = self.ajax('student_submit', block, {'answer': answer})
+        self.assertEqual(resp.status_code, 200)
+        # pylint: disable=no-member
+        self.assertEqual(resp.data, {'success': True,
+                                     'answer': answer})
+
+    # pylint: disable=unused-argument
+    def check_response(self, block_urlname, expected_string, present):
+        """
+        Confirm that we have a 200 response code (no server error)
+
+        Confirm that a string is either present or not present in the
+        response
+        """
+        response = self.render_block(block_urlname)
+        self.assertEqual(response.status_code, 200)
+
+        if present:
+            self.assertTrue(expected_string in response.content)
+        else:
+            self.assertFalse(expected_string in response.content)
+
+
+    def test_submit_compare(self):
+        """
+        We submit something, pull a few hints, and submit again.
+        """
+        self.select_student(0)
+        # We confirm we don't have errors rendering the student view
+        self.check_response('submit_0', "Before you begin the simulation", True)
+        self.check_response('submit_0', "because. Yeah", False)
+        self.student_submit('submit_0',
+                            "I think because. Yeah. Because")
+        self.check_response('submit_0', "because. Yeah", True)
+        self.student_submit('submit_0',
+                            "No. Another reason")
+        self.check_response('submit_0', "because. Yeah", False)
+        self.check_response('submit_0', "Another reason", True)


### PR DESCRIPTION
This adds a basic test case to this XBlock. In order to run the test, use: 

```
paver test_system -t openedx/tests/xblock_integration/test_external_xblocks.py
```

Note that I have not confirmed whether this works on `master`. The test framework has several bugs with a PR to fix several bugs in flight (https://github.com/edx/edx-platform/pull/10747), and I'm working off of a branch with those tests fixed.

@strader 
